### PR TITLE
GjsDBusImplementation: unref the invocation passed to method_call()

### DIFF
--- a/libgjs-private/gjs-gdbus-wrapper.cpp
+++ b/libgjs-private/gjs-gdbus-wrapper.cpp
@@ -45,6 +45,7 @@ gjs_dbus_implementation_method_call(GDBusConnection       *connection,
     GjsDBusImplementation *self = GJS_DBUS_IMPLEMENTATION (user_data);
 
     g_signal_emit(self, signals[SIGNAL_HANDLE_METHOD], 0, method_name, parameters, invocation);
+    g_object_unref (invocation);
 }
 
 static GVariant *


### PR DESCRIPTION
In C code, the reference passed to the method_call() virtual function
would be passed to the return_value/error function that is eventually
called. But since these functions are called from JS, and the calling
convention is normalized, we need to unref reference passed to
method_call ourselves. See GLib bug 738259 for a more complete discussion.

https://bugzilla.gnome.org/show_bug.cgi?id=738122

[endlessm/eos-shell#4071]
