### PR TITLE
gi: Call init_object_private after creating JSObject for GObject

### DIFF
--- a/gi/object.cpp
+++ b/gi/object.cpp
@@ -1248,7 +1248,7 @@ object_instance_init (JSContext *context,
     JSObject *old_jsobj;
     GObject *gobj;
 
-    priv = init_object_private(context, *object);
+    priv = (ObjectInstance *) JS_GetPrivate(*object);
 
     gtype = priv->gtype;
     g_assert(gtype != G_TYPE_NONE);
@@ -1335,6 +1335,11 @@ GJS_NATIVE_CONSTRUCTOR_DECLARE(object_instance)
     jsid object_init_name;
 
     GJS_NATIVE_CONSTRUCTOR_PRELUDE(object_instance);
+
+    /* Init the private variable before we do anything else. If a garbage
+     * collection happens when calling the init function then this object
+     * might be traced and we will end up dereferencing a null pointer */
+    init_object_private(context, object);
 
     object_init_name = gjs_context_get_const_string(context, GJS_STRING_GOBJECT_INIT);
     if (!gjs_object_require_property(context, object, "GObject instance", object_init_name, &initer))


### PR DESCRIPTION
Previously we called this function in init_func (eg, _init), but
that left open a window for a garbage collection cycle to occurr
because we were getting and setting properties in the GObject
constructor which were calling into JS code.

When the newly constructed but not yet init'd object got traced,
a null pointer was dereferenced.

Fixes #742517

endlessm/eos-shell#2264