### PR TITLE
coverage: Handle numerous other expression types in coverage.js

### DIFF
--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -28,7 +28,6 @@ function testExpressionLinesFoundForAssignmentExpressionSides() {
                       JSUnit.assertEquals);
 }
 
-
 function testExpressionLinesFoundForLinesInsideFunctions() {
     let foundLinesInsideNamedFunction =
         parseScriptForExpressionLines("function f(a, b) {\n" +
@@ -177,7 +176,7 @@ function testExpressionLinesFoundForIfExits() {
                       JSUnit.assertEquals);
 }
 
-function testExpressionLinesFoundForFirstLineOfMultilineIfTests() {
+function testExpressionLinesFoundForAllLinesOfMultilineIfTests() {
     let foundLinesInsideMultilineIfTest =
         parseScriptForExpressionLines("if (1 > 0 &&\n" +
                                       "    2 > 0 &&\n" +
@@ -185,7 +184,7 @@ function testExpressionLinesFoundForFirstLineOfMultilineIfTests() {
                                       "    let a = 3;\n" +
                                       "}\n");
     assertArrayEquals(foundLinesInsideMultilineIfTest,
-                      [1, 4],
+                      [1, 2, 3, 4],
                       JSUnit.assertEquals);
 }
 
@@ -310,6 +309,303 @@ function testFunctionsFoundOnSameLineButDifferentiatedOnArgs() {
                           { name: "f1", line: 1, n_params: 0 },
                           { name: null, line: 1, n_params: 1 },
                           { name: null, line: 1, n_params: 2 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideArrayExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = [function() {}];\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 },
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideArrowExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("(a) => (function(){})();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideSequence() {
+    let foundFunctions =
+        parseScriptForFunctionNames("(function(a){})()," +
+                                    "(function(a, b){})();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 1 },
+                          { name: null, line: 1, n_params: 2 },
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideUnaryExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = (function () {}())++;\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 },
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideBinaryExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = function (a) {}() +" +
+                                    " function (a, b) {}();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 1 },
+                          { name: null, line: 1, n_params: 2 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideAssignmentExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = function () {}();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideUpdateExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a;\n" +
+                                    "a += function () {}();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 2, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideIfConditions() {
+    let foundFunctions =
+        parseScriptForFunctionNames("if (function (a) {}(a) >" +
+                                    "    function (a, b) {}(a, b)) {};\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 1 },
+                          { name: null, line: 1, n_params: 2 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideWhileConditions() {
+    let foundFunctions =
+        parseScriptForFunctionNames("while (function (a) {}(a) >" +
+                                    "       function (a, b) {}(a, b)) {};\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 1 },
+                          { name: null, line: 1, n_params: 2 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForInitializer() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (function() {};;) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+/* SpiderMonkey parses for (let i = <init>; <cond>; <update>) as though
+ * they were let i = <init> { for (; <cond> <update>) } so test the
+ * LetStatement initializer case too */
+function testFunctionsInsideForLetInitializer() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (let i = function() {};;) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForVarInitializer() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (var i = function() {};;) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForCondition() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (; function() {}();) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForIncrement() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (;;function() {}()) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForInObject() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (let x in function() {}()) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForInObject() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for each (x in function() {}()) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInsideForOfObject() {
+    let foundFunctions =
+        parseScriptForFunctionNames("for (x of (function(){}())) {}\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsUsedAsObjectFound() {
+    let foundFunctions =
+        parseScriptForFunctionNames("f = function() { }.bind();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsUsedAsObjectDynamicProp() {
+    let foundFunctions =
+        parseScriptForFunctionNames("f = function() { }['bind']();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsOnEitherSideOfLogicalExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let f = function(a) { } ||" +
+                                    " function(a, b) { };\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 1, n_params: 1 },
+                          { name: null, line: 1, n_params: 2 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsOnEitherSideOfConditionalExpression() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a\n" +
+                                    "let f = a ? function(a) { }() :" +
+                                    " function(a, b) { }();\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 2, n_params: 1 },
+                          { name: null, line: 2, n_params: 2 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsYielded() {
+    let foundFunctions =
+        parseScriptForFunctionNames("function a () { yield function (){} };\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: "a", line: 1, n_params: 0 },
+                          { name: null, line: 1, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInArrayComprehensionBody() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = new Array(1);\n" +
+                                    "let b = [function () {} for (i of a)];\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 2, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInArrayComprehensionBlock() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = new Array(1);\n" +
+                                    "let b = [i for (i of function () {})];\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 2, n_params: 0 }
+                      ],
+                      functionDeclarationsEqual);
+}
+
+function testFunctionsInArrayComprehensionFilter() {
+    let foundFunctions =
+        parseScriptForFunctionNames("let a = new Array(1);\n" +
+                                    "let b = [i for (i of a)" +
+                                    "if (function () {} ())];\n");
+
+    assertArrayEquals(foundFunctions,
+                      [
+                          { name: null, line: 2, n_params: 0 }
                       ],
                       functionDeclarationsEqual);
 }

--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -57,7 +57,7 @@ function testExpressionLinesFoundForLinesInsideAnonymousFunctions() {
 function testExpressionLinesFoundForBodyOfFunctionProperty() {
     let foundLinesInsideFunctionProperty =
         parseScriptForExpressionLines("var o = {\n" +
-                                      "    foo: function () {\n" +
+                                      "    foo: function() {\n" +
                                       "        let x = a;\n" +
                                       "    }\n" +
                                       "};\n");
@@ -180,7 +180,7 @@ function testExpressionLinesFoundForAllLinesOfMultilineIfTests() {
     let foundLinesInsideMultilineIfTest =
         parseScriptForExpressionLines("if (1 > 0 &&\n" +
                                       "    2 > 0 &&\n" +
-                                      "    3 > 0){\n" +
+                                      "    3 > 0) {\n" +
                                       "    let a = 3;\n" +
                                       "}\n");
     assertArrayEquals(foundLinesInsideMultilineIfTest,
@@ -300,8 +300,8 @@ function testFunctionsFoundOnSameLineButDifferentiatedOnArgs() {
      * one line */
     let foundFunctionsOnSameLine =
         parseScriptForFunctionNames("function f1() {" +
-                                    "    return (function (a) {" +
-                                    "        return function (a, b) {}" +
+                                    "    return (function(a) {" +
+                                    "        return function(a, b) {}" +
                                     "    });" +
                                     "}");
     assertArrayEquals(foundFunctionsOnSameLine,
@@ -326,7 +326,7 @@ function testFunctionsInsideArrayExpression() {
 
 function testFunctionsInsideArrowExpression() {
     let foundFunctions =
-        parseScriptForFunctionNames("(a) => (function(){})();\n");
+        parseScriptForFunctionNames("(a) => (function() {})();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -337,8 +337,8 @@ function testFunctionsInsideArrowExpression() {
 
 function testFunctionsInsideSequence() {
     let foundFunctions =
-        parseScriptForFunctionNames("(function(a){})()," +
-                                    "(function(a, b){})();\n");
+        parseScriptForFunctionNames("(function(a) {})()," +
+                                    "(function(a, b) {})();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -350,7 +350,7 @@ function testFunctionsInsideSequence() {
 
 function testFunctionsInsideUnaryExpression() {
     let foundFunctions =
-        parseScriptForFunctionNames("let a = (function () {}())++;\n");
+        parseScriptForFunctionNames("let a = (function() {}())++;\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -361,8 +361,8 @@ function testFunctionsInsideUnaryExpression() {
 
 function testFunctionsInsideBinaryExpression() {
     let foundFunctions =
-        parseScriptForFunctionNames("let a = function (a) {}() +" +
-                                    " function (a, b) {}();\n");
+        parseScriptForFunctionNames("let a = function(a) {}() +" +
+                                    " function(a, b) {}();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -374,7 +374,7 @@ function testFunctionsInsideBinaryExpression() {
 
 function testFunctionsInsideAssignmentExpression() {
     let foundFunctions =
-        parseScriptForFunctionNames("let a = function () {}();\n");
+        parseScriptForFunctionNames("let a = function() {}();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -386,7 +386,7 @@ function testFunctionsInsideAssignmentExpression() {
 function testFunctionsInsideUpdateExpression() {
     let foundFunctions =
         parseScriptForFunctionNames("let a;\n" +
-                                    "a += function () {}();\n");
+                                    "a += function() {}();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -397,8 +397,8 @@ function testFunctionsInsideUpdateExpression() {
 
 function testFunctionsInsideIfConditions() {
     let foundFunctions =
-        parseScriptForFunctionNames("if (function (a) {}(a) >" +
-                                    "    function (a, b) {}(a, b)) {};\n");
+        parseScriptForFunctionNames("if (function(a) {}(a) >" +
+                                    "    function(a, b) {}(a, b)) {}\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -410,8 +410,8 @@ function testFunctionsInsideIfConditions() {
 
 function testFunctionsInsideWhileConditions() {
     let foundFunctions =
-        parseScriptForFunctionNames("while (function (a) {}(a) >" +
-                                    "       function (a, b) {}(a, b)) {};\n");
+        parseScriptForFunctionNames("while (function(a) {}(a) >" +
+                                    "       function(a, b) {}(a, b)) {};\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -423,7 +423,7 @@ function testFunctionsInsideWhileConditions() {
 
 function testFunctionsInsideForInitializer() {
     let foundFunctions =
-        parseScriptForFunctionNames("for (function() {};;) {}\n");
+        parseScriptForFunctionNames("for (function() {}; ;) {}\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -437,7 +437,7 @@ function testFunctionsInsideForInitializer() {
  * LetStatement initializer case too */
 function testFunctionsInsideForLetInitializer() {
     let foundFunctions =
-        parseScriptForFunctionNames("for (let i = function() {};;) {}\n");
+        parseScriptForFunctionNames("for (let i = function() {}; ;) {}\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -448,7 +448,7 @@ function testFunctionsInsideForLetInitializer() {
 
 function testFunctionsInsideForVarInitializer() {
     let foundFunctions =
-        parseScriptForFunctionNames("for (var i = function() {};;) {}\n");
+        parseScriptForFunctionNames("for (var i = function() {}; ;) {}\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -470,7 +470,7 @@ function testFunctionsInsideForCondition() {
 
 function testFunctionsInsideForIncrement() {
     let foundFunctions =
-        parseScriptForFunctionNames("for (;;function() {}()) {}\n");
+        parseScriptForFunctionNames("for (; ;function() {}()) {}\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -503,7 +503,7 @@ function testFunctionsInsideForInObject() {
 
 function testFunctionsInsideForOfObject() {
     let foundFunctions =
-        parseScriptForFunctionNames("for (x of (function(){}())) {}\n");
+        parseScriptForFunctionNames("for (x of (function() {}())) {}\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -514,7 +514,7 @@ function testFunctionsInsideForOfObject() {
 
 function testFunctionsUsedAsObjectFound() {
     let foundFunctions =
-        parseScriptForFunctionNames("f = function() { }.bind();\n");
+        parseScriptForFunctionNames("f = function() {}.bind();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -525,7 +525,7 @@ function testFunctionsUsedAsObjectFound() {
 
 function testFunctionsUsedAsObjectDynamicProp() {
     let foundFunctions =
-        parseScriptForFunctionNames("f = function() { }['bind']();\n");
+        parseScriptForFunctionNames("f = function() {}['bind']();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -536,8 +536,8 @@ function testFunctionsUsedAsObjectDynamicProp() {
 
 function testFunctionsOnEitherSideOfLogicalExpression() {
     let foundFunctions =
-        parseScriptForFunctionNames("let f = function(a) { } ||" +
-                                    " function(a, b) { };\n");
+        parseScriptForFunctionNames("let f = function(a) {} ||" +
+                                    " function(a, b) {};\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -550,8 +550,8 @@ function testFunctionsOnEitherSideOfLogicalExpression() {
 function testFunctionsOnEitherSideOfConditionalExpression() {
     let foundFunctions =
         parseScriptForFunctionNames("let a\n" +
-                                    "let f = a ? function(a) { }() :" +
-                                    " function(a, b) { }();\n");
+                                    "let f = a ? function(a) {}() :" +
+                                    " function(a, b) {}();\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -563,7 +563,7 @@ function testFunctionsOnEitherSideOfConditionalExpression() {
 
 function testFunctionsYielded() {
     let foundFunctions =
-        parseScriptForFunctionNames("function a () { yield function (){} };\n");
+        parseScriptForFunctionNames("function a() { yield function (){} };\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -576,7 +576,7 @@ function testFunctionsYielded() {
 function testFunctionsInArrayComprehensionBody() {
     let foundFunctions =
         parseScriptForFunctionNames("let a = new Array(1);\n" +
-                                    "let b = [function () {} for (i of a)];\n");
+                                    "let b = [function() {} for (i of a)];\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -588,7 +588,7 @@ function testFunctionsInArrayComprehensionBody() {
 function testFunctionsInArrayComprehensionBlock() {
     let foundFunctions =
         parseScriptForFunctionNames("let a = new Array(1);\n" +
-                                    "let b = [i for (i of function () {})];\n");
+                                    "let b = [i for (i of function() {})];\n");
 
     assertArrayEquals(foundFunctions,
                       [
@@ -601,7 +601,7 @@ function testFunctionsInArrayComprehensionFilter() {
     let foundFunctions =
         parseScriptForFunctionNames("let a = new Array(1);\n" +
                                     "let b = [i for (i of a)" +
-                                    "if (function () {} ())];\n");
+                                    "if (function() {}())];\n");
 
     assertArrayEquals(foundFunctions,
                       [

--- a/test/gjs-test-coverage.cpp
+++ b/test/gjs-test-coverage.cpp
@@ -1104,6 +1104,44 @@ test_single_line_hit_written_to_coverage_data(gpointer      fixture_data,
 }
 
 static void
+test_hits_on_multiline_if_cond(gpointer      fixture_data,
+                                gconstpointer user_data)
+{
+    GjsCoverageToSingleOutputFileFixture *fixture = (GjsCoverageToSingleOutputFileFixture *) fixture_data;
+
+    const char *script_with_multine_if_cond =
+            "let a = 1;\n"
+            "let b = 1;\n"
+            "if (a &&\n"
+            "    b) {\n"
+            "}\n";
+
+    write_to_file_at_beginning(fixture->base_fixture.temporary_js_script_open_handle,
+                               script_with_multine_if_cond);
+
+    char *coverage_data_contents =
+        eval_script_and_get_coverage_data(fixture->base_fixture.context,
+                                          fixture->base_fixture.coverage,
+                                          fixture->base_fixture.temporary_js_script_filename,
+                                          fixture->output_file_directory,
+                                          NULL);
+
+    /* Hits on all lines, including both lines with a condition (3 and 4) */
+    LineCountIsMoreThanData data[] = {
+        { 1, 0 },
+        { 2, 0 },
+        { 3, 0 },
+        { 4, 0 }
+    };
+
+    g_assert(coverage_data_matches_value_for_key(coverage_data_contents,
+                                                 "DA:",
+                                                 line_hit_count_is_more_than,
+                                                 data));
+    g_free(coverage_data_contents);
+}
+
+static void
 test_full_line_tally_written_to_coverage_data(gpointer      fixture_data,
                                               gconstpointer user_data)
 {
@@ -1458,6 +1496,10 @@ void gjs_test_add_tests_for_coverage()
     add_test_for_fixture("/gjs/coverage/single_line_hit_written_to_coverage_data",
                          &coverage_to_single_output_fixture,
                          test_single_line_hit_written_to_coverage_data,
+                         NULL);
+    add_test_for_fixture("/gjs/coverage/hits_on_multiline_if_cond",
+                         &coverage_to_single_output_fixture,
+                         test_hits_on_multiline_if_cond,
                          NULL);
     add_test_for_fixture("/gjs/coverage/full_line_tally_written_to_coverage_data",
                          &coverage_to_single_output_fixture,


### PR DESCRIPTION
Certain expressions, like for (... in), for (... of), yield,
array comprehensions, logical expressions (a || b), etc were not
being traversed. These could contain function declarations. This
fixes numerous cases where an assertion might be raised by the
coverage machinery where the debugger enters a function it does
not know about.

Fixes #742535

endlessm/eos-shell#2264