### PR TITLE
Cherry-picks for #3303

### DIFF
--- a/gjs/coverage.cpp
+++ b/gjs/coverage.cpp
@@ -1217,6 +1217,8 @@ coverage_statistics_has_stale_cache(GjsCoverage *coverage)
     return JSVAL_TO_BOOLEAN(stale_cache_value);
 }
 
+static unsigned int _suppressed_coverage_messages_count = 0;
+
 void
 gjs_coverage_write_statistics(GjsCoverage *coverage,
                               const char  *output_directory)
@@ -1235,7 +1237,6 @@ gjs_coverage_write_statistics(GjsCoverage *coverage,
                                                "coverage.lcov",
                                                NULL);
     GFile *output_file = g_file_new_for_commandline_arg(output_file_path);
-    g_free(output_file_path);
 
     GOutputStream *ostream =
         G_OUTPUT_STREAM(g_file_append_to(output_file,
@@ -1273,6 +1274,15 @@ gjs_coverage_write_statistics(GjsCoverage *coverage,
         g_bytes_unref(cache_data);
     }
 
+    g_message("Wrote coverage statistics to %s", output_file_path);
+    if (_suppressed_coverage_messages_count) {
+        g_message("There were %i suppressed message(s) when collecting "
+                  "coverage, set GJS_SHOW_COVERAGE_MESSAGES to see them.",
+                  _suppressed_coverage_messages_count);
+        _suppressed_coverage_messages_count = 0;
+    }
+
+    g_free(output_file_path);
     g_array_unref(file_statistics_array);
     g_object_unref(ostream);
     g_object_unref(output_file);
@@ -1341,7 +1351,7 @@ coverage_log(JSContext *context,
              unsigned   argc,
              jsval     *vp)
 {
-    jsval *argv = JS_ARGV(context, vp);
+    JS::CallArgs argv = JS::CallArgsFromVp (argc, vp);
     char *s;
     JSExceptionState *exc_state;
     JSString *jstr;
@@ -1352,6 +1362,12 @@ coverage_log(JSContext *context,
     }
 
     JS_BeginRequest(context);
+
+    if (!g_getenv("GJS_SHOW_COVERAGE_MESSAGES")) {
+        _suppressed_coverage_messages_count++;
+        argv.rval().set(JSVAL_VOID);
+        return JS_TRUE;
+    }
 
     /* JS_ValueToString might throw, in which we will only
      *log that the value could be converted to string */
@@ -1376,7 +1392,7 @@ coverage_log(JSContext *context,
     g_free(s);
 
     JS_EndRequest(context);
-    JS_SET_RVAL(context, vp, JSVAL_VOID);
+    argv.rval().set(JSVAL_VOID);
     return JS_TRUE;
 }
 

--- a/gjs/coverage.cpp
+++ b/gjs/coverage.cpp
@@ -1345,9 +1345,9 @@ gjs_context_eval_file_in_compartment(GjsContext *context,
 }
 
 static JSBool
-coverage_warning(JSContext *context,
-                 unsigned   argc,
-                 jsval     *vp)
+coverage_log(JSContext *context,
+             unsigned   argc,
+             jsval     *vp)
 {
     jsval *argv = JS_ARGV(context, vp);
     char *s;
@@ -1355,7 +1355,7 @@ coverage_warning(JSContext *context,
     JSString *jstr;
 
     if (argc != 1) {
-        gjs_throw(context, "Must pass a single argument to warning()");
+        gjs_throw(context, "Must pass a single argument to log()");
         return JS_FALSE;
     }
 
@@ -1380,7 +1380,7 @@ coverage_warning(JSContext *context,
         return JS_FALSE;
     }
 
-    g_message("JS COVERAGE WARNING: %s", s);
+    g_message("JS COVERAGE MESSAGE: %s", s);
     g_free(s);
 
     JS_EndRequest(context);
@@ -1522,7 +1522,7 @@ coverage_get_file_contents(JSContext *context,
 }
 
 static JSFunctionSpec coverage_funcs[] = {
-    { "warning", JSOP_WRAPPER(coverage_warning), 1, GJS_MODULE_PROP_FLAGS },
+    { "log", JSOP_WRAPPER(coverage_log), 1, GJS_MODULE_PROP_FLAGS },
     { "getFileContents", JSOP_WRAPPER(coverage_get_file_contents), 1, GJS_MODULE_PROP_FLAGS },
     { "getFileModificationTime", JSOP_WRAPPER(coverage_get_file_modification_time), 1, GJS_MODULE_PROP_FLAGS },
     { "getFileChecksum", JSOP_WRAPPER(coverage_get_file_checksum), 1, GJS_MODULE_PROP_FLAGS },

--- a/gjs/coverage.cpp
+++ b/gjs/coverage.cpp
@@ -300,14 +300,6 @@ copy_source_file_to_coverage_output(const char *source,
     g_object_unref(source_file);
 }
 
-typedef struct _StatisticsPrintUserData {
-    GjsContext        *reflection_context;
-    GFileOutputStream *ostream;
-    const gchar       *output_directory;
-    JSContext         *context;
-    JSObject          *object;
-} StatisticsPrintUserData;
-
 /* This function will strip a URI scheme and return
  * the string with the URI scheme stripped or NULL
  * if the path was not a valid URI

--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -954,8 +954,6 @@ function testFunctionKeyFromFunctionWithoutNameIsAnonymous() {
     JSUnit.assertEquals(expectedFunctionKey, functionKeyForAnonymousFunction);
 }
 
-
-
 function testFunctionCounterMapReturnedForFunctionKeys() {
     let ast = {
         body: [{

--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -1211,11 +1211,11 @@ Coverage.getFileContents = function(filename) {
 
 Coverage.getFileChecksum = function(filename) {
     return "abcd";
-}
+};
 
 Coverage.getFileModificationTime = function(filename) {
     return [1, 2];
-}
+};
 
 function testCoverageStatisticsContainerFetchesValidStatisticsForFile() {
     let container = new Coverage.CoverageStatisticsContainer(MockFilenames);

--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -1210,7 +1210,7 @@ function testIncrementExpressionCountersThrowsIfLineOutOfRange() {
     ];
 
     JSUnit.assertRaises(function() {
-        Coverage._incrementExpressionCounters(expressionCounters, 2);
+        Coverage._incrementExpressionCounters(expressionCounters, 'script', 2);
     });
 }
 
@@ -1220,7 +1220,7 @@ function testIncrementExpressionCountersIncrementsIfInRange() {
         0
     ];
 
-    Coverage._incrementExpressionCounters(expressionCounters, 1);
+    Coverage._incrementExpressionCounters(expressionCounters, 'script', 1);
     JSUnit.assertEquals(1, expressionCounters[1]);
 }
 
@@ -1231,16 +1231,13 @@ function testWarnsIfWeHitANonExecutableLine() {
         undefined
     ];
 
-    let wasCalledContainer = { calledWith: undefined };
-    let reporter = function(cont) {
-        let container = cont;
-        return function(line) {
-            container.calledWith = line;
-        };
-    } (wasCalledContainer);
+    let messages = _fetchLogMessagesFrom(function() {
+        Coverage._incrementExpressionCounters(expressionCounters, 'script', 2);
+    });
 
-    Coverage._incrementExpressionCounters(expressionCounters, 2, reporter);
-    JSUnit.assertEquals(wasCalledContainer.calledWith, 2);
+    JSUnit.assertEquals(messages[0],
+                        "script:2 Executed line previously marked " +
+                        "non-executable by Reflect");
     JSUnit.assertEquals(expressionCounters[2], 1);
 }
 

--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -362,6 +362,7 @@ function testFunctionsInsideArrowExpression() {
 
     assertArrayEquals(foundFunctions,
                       [
+                          { key: "(anonymous):1:1", line: 1, n_params: 1 },
                           { key: "(anonymous):1:0", line: 1, n_params: 0 }
                       ],
                       functionDeclarationsEqual);

--- a/installed-tests/js/testCoverage.js
+++ b/installed-tests/js/testCoverage.js
@@ -173,6 +173,22 @@ function testExpressionLinesFoundForCaseStatementsCharacters() {
                       JSUnit.assertEquals);
 }
 
+function testExpressionLinesFoundForCaseStatementsCharacters() {
+    let foundLinesInsideCaseStatements =
+        parseScriptForExpressionLines("var a = 'a';\n" +
+                                      "switch (a) {\n" +
+                                      "case 'a':\n" +
+                                      "    a++;\n" +
+                                      "    break;\n" +
+                                      "case 'b':\n" +
+                                      "    a++;\n" +
+                                      "    break;\n" +
+                                      "}\n");
+    assertArrayEquals(foundLinesInsideCaseStatements,
+                      [1, 2, 4, 5, 7, 8],
+                      JSUnit.assertEquals);
+}
+
 function testExpressionLinesFoundForLoop() {
     let foundLinesInsideLoop =
         parseScriptForExpressionLines("for (let i = 0; i < 1; i++) {\n" +

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -763,12 +763,6 @@ function CoverageStatisticsContainer(prefixes, cache) {
                      });
                  }
             }
-            cacheDataForFilename.functions = Object.keys(statisticsForFilename.functionCounters).map(function(key) {
-                return {
-                    key: key,
-                    line: Number(key.split(':')[1])
-                };
-            });
             cache_data[filename] = cacheDataForFilename;
         });
         return JSON.stringify(cache_data);

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -689,7 +689,7 @@ function _fetchCountersFromReflection(contents, nLines) {
 function CoverageStatisticsContainer(prefixes, cache) {
     /* Copy the files array, so that it can be re-used in the tests */
     let cachedASTs = cache !== undefined ? JSON.parse(cache) : null;
-    let coveredFiles = {}
+    let coveredFiles = {};
     let cacheMisses = 0;
 
     function wantsStatisticsFor(filename) {
@@ -727,7 +727,7 @@ function CoverageStatisticsContainer(prefixes, cache) {
     }
 
     this.stringify = function() {
-        let cache_data = {}
+        let cache_data = {};
         Object.keys(coveredFiles).forEach(function(filename) {
             let statisticsForFilename = coveredFiles[filename];
             let mtime = getFileModificationTime(filename);
@@ -754,7 +754,7 @@ function CoverageStatisticsContainer(prefixes, cache) {
                      cacheDataForFilename.lines.push(line_index);
 
                  if (statisticsForFilename.branchCounters[line_index] !== undefined) {
-                     let branchCounters = statisticsForFilename.branchCounters[line_index]
+                     let branchCounters = statisticsForFilename.branchCounters[line_index];
                      cacheDataForFilename.branches.push({
                          point: statisticsForFilename.branchCounters[line_index].point,
                          exits: statisticsForFilename.branchCounters[line_index].exits.map(function(exit) {
@@ -766,7 +766,7 @@ function CoverageStatisticsContainer(prefixes, cache) {
             cache_data[filename] = cacheDataForFilename;
         });
         return JSON.stringify(cache_data);
-    }
+    };
 
     this.getCoveredFiles = function() {
         return Object.keys(coveredFiles);

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -477,13 +477,27 @@ function _branchesToBranchCounters(branches, nLines) {
     return counters;
 }
 
-function _functionsToFunctionCounters(functions) {
+function _functionsToFunctionCounters(script, functions) {
     let functionCounters = {};
 
     functions.forEach(function(func) {
-        functionCounters[func.key] = {
-            hitCount: 0
-        };
+        let [name, line, args] = func.key.split(':');
+
+        if (functionCounters[name] === undefined) {
+            functionCounters[name] = {};
+        }
+
+        if (functionCounters[name][line] === undefined) {
+            functionCounters[name][line] = {};
+        }
+
+        if (functionCounters[name][line][args] === undefined) {
+            functionCounters[name][line][args] = { hitCount: 0 };
+        } else {
+            log(script + ':' + line + ' Function identified as ' +
+                func.key + ' already seen in this file. Function coverage ' +
+                'will be incomplete.');
+        }
     });
 
     return functionCounters;
@@ -497,6 +511,59 @@ function _populateKnownFunctions(functions, nLines) {
     });
 
     return knownFunctions;
+}
+
+function _identifyFunctionCounterInLinePartForDescription(linePart,
+                                                          nArgs) {
+    /* There is only one potential option for this line. We might have been
+     * called with the wrong number of arguments, but it doesn't matter. */
+    if (Object.getOwnPropertyNames(linePart).length === 1)
+        return linePart[Object.getOwnPropertyNames(linePart)[0]];
+
+    /* Have to disambiguate using nArgs and we have an exact match. */
+    if (linePart[nArgs] !== undefined)
+        return linePart[nArgs];
+
+    /* There are multiple options on this line. Pick the one where
+     * we satisfy the number of arguments exactly, or failing that,
+     * go through each and pick the closest. */
+    let allNArgsOptions = Object.keys(linePart).map(function(key) {
+        return parseInt(key);
+    });
+
+    let closest = allNArgsOptions.reduce(function(prev, current, index, array) {
+        let nArgsOption = array[index];
+        if (Math.abs(nArgsOption - nArgs) < Math.abs(current - nArgs)) {
+            return nArgsOption;
+        }
+
+        return current;
+    });
+
+    return linePart[String(closest)];
+}
+
+function _identifyFunctionCounterForDescription(functionCounters,
+                                                name,
+                                                line,
+                                                nArgs) {
+    let candidateCounter = functionCounters[name];
+
+    if (candidateCounter === undefined)
+        return null;
+
+    if (Object.getOwnPropertyNames(candidateCounter).length === 1) {
+        let linePart = candidateCounter[Object.getOwnPropertyNames(candidateCounter)[0]];
+        return _identifyFunctionCounterInLinePartForDescription(linePart, nArgs);
+    }
+
+    let linePart = functionCounters[name][line];
+
+    if (linePart === undefined) {
+        return null;
+    }
+
+    return _identifyFunctionCounterInLinePartForDescription(linePart, nArgs);
 }
 
 /**
@@ -517,25 +584,30 @@ function _incrementFunctionCounters(functionCounters,
                                     name,
                                     line,
                                     nArgs) {
-    let functionKey = name + ':' + line + ':' + nArgs;
-    let functionCountersForKey = functionCounters[functionKey];
+    let functionCountersForKey = _identifyFunctionCounterForDescription(functionCounters,
+                                                                        name,
+                                                                        line,
+                                                                        nArgs);
 
     /* Its possible that the JS Engine might enter a funciton
      * at an executable line which is a little bit past the
      * actual definition. Roll backwards until we reach the
      * last known function definition line which we kept
      * track of earlier to see if we can find this function first */
-    if (functionCountersForKey === undefined) {
+    if (functionCountersForKey === null) {
         do {
             --line;
-            functionKey = name + ':' + line + ':' + nArgs;
-            functionCountersForKey = functionCounters[functionKey];
+            functionCountersForKey = _identifyFunctionCounterForDescription(functionCounters,
+                                                                            name,
+                                                                            line,
+                                                                            nArgs);
         } while (linesWithKnownFunctions[line] !== true && line > 0);
     }
 
-    if (functionCountersForKey !== undefined) {
+    if (functionCountersForKey !== null) {
         functionCountersForKey.hitCount++;
     } else {
+        let functionKey = [name, line, nArgs].join(':');
         throw new Error("expected Reflect to find function " + functionKey);
     }
 }
@@ -615,16 +687,24 @@ function _BranchTracker(branchCounters) {
 
 function _convertFunctionCountersToArray(functionCounters) {
     let arrayReturn = [];
-    /* functionCounters is an object so convert it to
+    /* functionCounters is an object so explore it to create a
+     * set of function keys and then convert it to
      * an array-of-object using the key as a property
      * of that object */
-    for (let key of Object.getOwnPropertyNames(functionCounters)) {
-        let func = functionCounters[key];
-        /* The name of the function contains its line, after the first
-         * colon. Split the name and retrieve it here */
-        arrayReturn.push({ name: key,
-                           line: Number(key.split(':')[1]),
-                           hitCount: func.hitCount });
+    for (let name of Object.getOwnPropertyNames(functionCounters)) {
+        let namePart = functionCounters[name];
+
+        for (let line of Object.getOwnPropertyNames(namePart)) {
+            let linePart = functionCounters[name][line];
+
+            for (let nArgs of Object.getOwnPropertyNames(linePart)) {
+                let functionKey = [name, line, nArgs].join(':');
+                arrayReturn.push({ name: functionKey,
+                                   line: Number(line),
+                                   nArgs: nArgs,
+                                   hitCount: linePart[nArgs].hitCount });
+            }
+        }
     }
 
     arrayReturn.sort(function(left, right) {
@@ -663,7 +743,7 @@ function _fetchCountersFromCache(filename, cache, nLines) {
         return {
             expressionCounters: _expressionLinesToCounters(cache_for_file.lines, nLines),
             branchCounters: _branchesToBranchCounters(cache_for_file.branches, nLines),
-            functionCounters: _functionsToFunctionCounters(functions),
+            functionCounters: _functionsToFunctionCounters(filename, functions),
             linesWithKnownFunctions: _populateKnownFunctions(functions, nLines),
             nLines: nLines
         };
@@ -672,14 +752,14 @@ function _fetchCountersFromCache(filename, cache, nLines) {
     return null;
 }
 
-function _fetchCountersFromReflection(contents, nLines) {
+function _fetchCountersFromReflection(filename, contents, nLines) {
     let reflection = Reflect.parse(contents);
     let functions = functionsForAST(reflection);
 
     return {
         expressionCounters: _expressionLinesToCounters(expressionLinesForAST(reflection), nLines),
         branchCounters: _branchesToBranchCounters(branchesForAST(reflection), nLines),
-        functionCounters: _functionsToFunctionCounters(functions),
+        functionCounters: _functionsToFunctionCounters(filename, functions),
         linesWithKnownFunctions: _populateKnownFunctions(functions, nLines),
         nLines: nLines
     };
@@ -704,7 +784,7 @@ function CoverageStatisticsContainer(prefixes, cache) {
         let counters = _fetchCountersFromCache(filename, cachedASTs, nLines);
         if (counters === null) {
             cacheMisses++;
-            counters = _fetchCountersFromReflection(contents, nLines);
+            counters = _fetchCountersFromReflection(filename, contents, nLines);
         }
 
         if (counters === null)
@@ -735,10 +815,10 @@ function CoverageStatisticsContainer(prefixes, cache) {
                 checksum: mtime === null ? getFileChecksum(filename) : null,
                 lines: [],
                 branches: [],
-                functions: Object.keys(statisticsForFilename.functionCounters).map(function(key) {
+                functions: _convertFunctionCountersToArray(statisticsForFilename.functionCounters).map(function(func) {
                     return {
-                        key: key,
-                        line: Number(key.split(':')[1])
+                        key: func.name,
+                        line: func.line
                     };
                 })
             };

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -618,12 +618,10 @@ function _incrementFunctionCounters(functionCounters,
  * expressonCounters: An array of either a hit count for a found
  * executable line or undefined for a known non-executable line.
  * line: an executed line
- * reporter: A function a single integer to report back when
- * we executed lines that we didn't expect
  */
 function _incrementExpressionCounters(expressionCounters,
-                                      offsetLine,
-                                      reporter) {
+                                      script,
+                                      offsetLine) {
     let expressionCountersLen = expressionCounters.length;
 
     if (offsetLine >= expressionCountersLen)
@@ -648,7 +646,8 @@ function _incrementExpressionCounters(expressionCounters,
      * and BlockStatement, neither of which would ordinarily be
      * executed */
     if (expressionCounters[offsetLine] === undefined) {
-        reporter(offsetLine);
+        log(script + ':' + offsetLine + ' Executed line previously marked ' +
+            'non-executable by Reflect');
         expressionCounters[offsetLine] = 0;
     }
 
@@ -954,15 +953,8 @@ function CoverageStatistics(prefixes, cache) {
 
             try {
                 _incrementExpressionCounters(statistics.expressionCounters,
-                                             offsetLine,
-                                             function(line) {
-                                                 log("executed " +
-                                                     frame.script.url +
-                                                     ":" +
-                                                     line +
-                                                     " which we thought" +
-                                                     " wasn't executable");
-                                             });
+                                             frame.script.url,
+                                             offsetLine);
                 this._branchTracker.incrementBranchCounters(offsetLine);
             } catch (e) {
                 /* Something bad happened. Log the exception and delete

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -561,7 +561,7 @@ function _incrementExpressionCounters(expressionCounters,
      * mean that the reflection machinery is not doing its job, so we should
      * print a debug message about it in case someone is interested.
      *
-     * The reason why we don't have a proper warning is because it
+     * The reason why we don't have a proper log is because it
      * is difficult to determine what the SpiderMonkey program counter
      * will actually pass over, especially function declarations for some
      * reason:
@@ -576,9 +576,7 @@ function _incrementExpressionCounters(expressionCounters,
      * and BlockStatement, neither of which would ordinarily be
      * executed */
     if (expressionCounters[offsetLine] === undefined) {
-        if (reporter !== undefined)
-            reporter(offsetLine);
-
+        reporter(offsetLine);
         expressionCounters[offsetLine] = 0;
     }
 
@@ -831,15 +829,15 @@ function CoverageStatistics(prefixes, cache) {
             }
         } catch (e) {
             /* We don't care about this frame, return */
-            warning(e.message + " " + e.stack);
+            log(e.message + " " + e.stack);
             return undefined;
         }
 
         function _logExceptionAndReset(exception, callee, line) {
-            warning(exception.fileName + ":" + exception.lineNumber + " (processing " +
-                    frame.script.url + ":" + callee + ":" + line + ") - " +
-                    exception.message);
-            warning("Will not log statistics for this file");
+            log(exception.fileName + ":" + exception.lineNumber +
+                " (processing " + frame.script.url + ":" + callee + ":" +
+                line + ") - " + exception.message);
+            log("Will not log statistics for this file");
             frame.onStep = undefined;
             frame._branchTracker = undefined;
             deleteStatistics(frame.script.url);
@@ -878,12 +876,12 @@ function CoverageStatistics(prefixes, cache) {
                 _incrementExpressionCounters(statistics.expressionCounters,
                                              offsetLine,
                                              function(line) {
-                                                 warning("executed " +
-                                                         frame.script.url +
-                                                         ":" +
-                                                         line +
-                                                         " which we thought" +
-                                                         " wasn't executable");
+                                                 log("executed " +
+                                                     frame.script.url +
+                                                     ":" +
+                                                     line +
+                                                     " which we thought" +
+                                                     " wasn't executable");
                                              });
                 this._branchTracker.incrementBranchCounters(offsetLine);
             } catch (e) {

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -219,6 +219,7 @@ function functionsForNode(node) {
     switch (node.type) {
     case 'FunctionDeclaration':
     case 'FunctionExpression':
+    case 'ArrowExpression':
         functionNames.push({ key: _getFunctionKeyFromReflectedFunction(node),
                              line: node.loc.start.line,
                              n_params: node.params.length });

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -774,11 +774,7 @@ function CoverageStatisticsContainer(prefixes, cache) {
     };
 
     this.fetchStatistics = function(filename) {
-        let statistics = ensureStatisticsFor(filename);
-
-        if (statistics === undefined)
-            throw new Error('Not tracking statistics for ' + filename);
-        return statistics;
+        return ensureStatisticsFor(filename);
     };
 
     this.staleCache = function() {
@@ -830,8 +826,12 @@ function CoverageStatistics(prefixes, cache) {
 
         try {
             statistics = fetchStatistics(frame.script.url);
+            if (!statistics) {
+                return undefined;
+            }
         } catch (e) {
             /* We don't care about this frame, return */
+            warning(e.message + " " + e.stack);
             return undefined;
         }
 


### PR DESCRIPTION
Cherry-picks for upstream issue #751732 which was blocking endlessm/eos-sdk#3303

Note that 0fdc393 was required in order to make this build, since upstream uses `JS::CallArgs` instead of the `argv` pointer for native function arguments and a change was made to `coverage_log` which relies on that change. The change to `coverage_log` could be trivially adapted to use the old pointer-based approach if we don't want to take that commit, although the upstream approach is technically the more correct one.