### PR TITLE
gettext: Add a binding for setlocale()

### DIFF
--- a/Makefile-insttest.am
+++ b/Makefile-insttest.am
@@ -125,6 +125,7 @@ dist_jstests_DATA += \
 	installed-tests/js/testClass.js			\
 	installed-tests/js/testCoverage.js \
 	installed-tests/js/testGDBus.js			\
+	installed-tests/js/testGettext.js			\
 	installed-tests/js/testEverythingBasic.js		\
 	installed-tests/js/testEverythingEncapsulated.js	\
 	installed-tests/js/testFormat.js		\

--- a/installed-tests/js/testGettext.js
+++ b/installed-tests/js/testGettext.js
@@ -1,0 +1,15 @@
+// -*- mode: js; indent-tabs-mode: nil -*-
+
+// Tests for the Gettext module.
+const Gettext = imports.gettext;
+const JSUnit = imports.jsUnit;
+
+function testSetlocale() {
+    // We don't actually want to mess with the locale, so just use setlocale's
+    // query mode. We also don't want to make this test locale-dependent, so
+    // just assert that it returns a string with at least length 1 (the shortest
+    // locale is "C".)
+    JSUnit.assert(Gettext.setlocale(Gettext.LocaleCategory.ALL, null).length >= 1);
+}
+
+JSUnit.gjstestRun(this, JSUnit.setUp, JSUnit.tearDown);

--- a/libgjs-private/gjs-util.cpp
+++ b/libgjs-private/gjs-util.cpp
@@ -34,6 +34,50 @@ gjs_format_int_alternative_output(int n)
     return g_strdup_printf("%Id", n);
 }
 
+GType
+gjs_locale_category_get_type(void)
+{
+  static volatile size_t g_define_type_id__volatile = 0;
+  if (g_once_init_enter(&g_define_type_id__volatile)) {
+      static const GEnumValue v[] = {
+          { GJS_LOCALE_CATEGORY_ALL, "GJS_LOCALE_CATEGORY_ALL", "all" },
+          { GJS_LOCALE_CATEGORY_ADDRESS, "GJS_LOCALE_CATEGORY_ADDRESS", "address" },
+          { GJS_LOCALE_CATEGORY_COLLATE, "GJS_LOCALE_CATEGORY_COLLATE", "collate" },
+          { GJS_LOCALE_CATEGORY_CTYPE, "GJS_LOCALE_CATEGORY_CTYPE", "ctype" },
+          { GJS_LOCALE_CATEGORY_IDENTIFICATION, "GJS_LOCALE_CATEGORY_IDENTIFICATION", "identification" },
+          { GJS_LOCALE_CATEGORY_MEASUREMENT, "GJS_LOCALE_CATEGORY_MEASUREMENT", "measurement" },
+          { GJS_LOCALE_CATEGORY_MESSAGES, "GJS_LOCALE_CATEGORY_MESSAGES", "messages" },
+          { GJS_LOCALE_CATEGORY_MONETARY, "GJS_LOCALE_CATEGORY_MONETARY", "monetary" },
+          { GJS_LOCALE_CATEGORY_NAME, "GJS_LOCALE_CATEGORY_NAME", "name" },
+          { GJS_LOCALE_CATEGORY_NUMERIC, "GJS_LOCALE_CATEGORY_NUMERIC", "numeric" },
+          { GJS_LOCALE_CATEGORY_PAPER, "GJS_LOCALE_CATEGORY_PAPER", "paper" },
+          { GJS_LOCALE_CATEGORY_TELEPHONE, "GJS_LOCALE_CATEGORY_TELEPHONE", "telephone" },
+          { GJS_LOCALE_CATEGORY_TIME, "GJS_LOCALE_CATEGORY_TIME", "time" },
+          { 0, NULL, NULL }
+      };
+      GType g_define_type_id =
+        g_enum_register_static(g_intern_static_string("GjsLocaleCategory"), v);
+
+      g_once_init_leave(&g_define_type_id__volatile, g_define_type_id);
+  }
+  return g_define_type_id__volatile;
+}
+
+/**
+ * gjs_setlocale:
+ * @category:
+ * @locale: (allow-none):
+ *
+ * Returns:
+ */
+const char *
+gjs_setlocale(GjsLocaleCategory category, const char *locale)
+{
+    /* According to man setlocale(3), the return value may be allocated in
+     * static storage. */
+    return (const char *) setlocale(category, locale);
+}
+
 void
 gjs_textdomain(const char *domain)
 {

--- a/libgjs-private/gjs-util.h
+++ b/libgjs-private/gjs-util.h
@@ -23,6 +23,7 @@
 #ifndef __GJS_PRIVATE_UTIL_H__
 #define __GJS_PRIVATE_UTIL_H__
 
+#include <locale.h>
 #include <glib.h>
 #include <glib-object.h>
 
@@ -32,9 +33,29 @@ G_BEGIN_DECLS
 char * gjs_format_int_alternative_output (int n);
 
 /* For imports.gettext */
-void gjs_textdomain     (const char *domain);
-void gjs_bindtextdomain (const char *domain,
-                         const char *location);
+typedef enum
+{
+  GJS_LOCALE_CATEGORY_ALL = LC_ALL,
+  GJS_LOCALE_CATEGORY_ADDRESS = LC_ADDRESS,
+  GJS_LOCALE_CATEGORY_COLLATE = LC_COLLATE,
+  GJS_LOCALE_CATEGORY_CTYPE = LC_CTYPE,
+  GJS_LOCALE_CATEGORY_IDENTIFICATION = LC_IDENTIFICATION,
+  GJS_LOCALE_CATEGORY_MEASUREMENT = LC_MEASUREMENT,
+  GJS_LOCALE_CATEGORY_MESSAGES = LC_MESSAGES,
+  GJS_LOCALE_CATEGORY_MONETARY = LC_MONETARY,
+  GJS_LOCALE_CATEGORY_NAME = LC_NAME,
+  GJS_LOCALE_CATEGORY_NUMERIC = LC_NUMERIC,
+  GJS_LOCALE_CATEGORY_PAPER = LC_PAPER,
+  GJS_LOCALE_CATEGORY_TELEPHONE = LC_TELEPHONE,
+  GJS_LOCALE_CATEGORY_TIME = LC_TIME
+} GjsLocaleCategory;
+
+const char *gjs_setlocale                (GjsLocaleCategory category,
+                                          const char       *locale);
+void        gjs_textdomain               (const char *domain);
+void        gjs_bindtextdomain           (const char *domain,
+                                          const char *location);
+GType       gjs_locale_category_get_type (void) G_GNUC_CONST;
 
 /* For imports.overrides.GObject */
 GParamFlags gjs_param_spec_get_flags (GParamSpec *pspec);

--- a/modules/gettext.js
+++ b/modules/gettext.js
@@ -35,6 +35,12 @@
 const GLib = imports.gi.GLib;
 const GjsPrivate = imports.gi.GjsPrivate;
 
+const LocaleCategory = GjsPrivate.LocaleCategory;
+
+function setlocale(category, locale) {
+    return GjsPrivate.setlocale(category, locale);
+}
+
 function textdomain(domain) {
     return GjsPrivate.textdomain(domain);
 }


### PR DESCRIPTION
This adds a Gettext.setlocale() binding for the setlocale() function, which is
sometimes needed in programs that use Gettext.

Also adds a Gettext.LocaleCategory enum which contains all the LC_... values
from locale.h, for use as the first parameter of this function.

[endlessm/eos-shell#5411]