### PR TITLE
Reinstate libgjs-dev -> libmozjs-31-dev dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+gjs (1.47.3-0endless2) unstable; urgency=medium
+
+  * debian/control{,.in}: Reinstate dependency of libgjs-dev on
+    libmozjs-31-dev, it was a mistake to remove it because it's still
+    needed when you link statically.
+
+ -- Philip Chimento <philip@endless>  Thu, 22 Dec 2016 14:51:16 -0700
+
 gjs (1.47.3-0endless1) unstable; urgency=medium
 
   * debian/control{,.in}: Remove <!nocheck> from dependencies as our OBS

--- a/debian/control
+++ b/debian/control
@@ -76,7 +76,8 @@ Section: libdevel
 Depends: ${misc:Depends},
          gjs,
          libgjs0e (= ${binary:Version}),
-         libgirepository1.0-dev (>= 1.41.4)
+         libgirepository1.0-dev (>= 1.41.4),
+         libmozjs-31-dev
 Description: Mozilla-based javascript bindings for the GNOME platform
  Makes it possible for applications to use all of GNOME's platform
  libraries using the Javascript language. It's mainly based on the

--- a/debian/control.in
+++ b/debian/control.in
@@ -72,7 +72,8 @@ Section: libdevel
 Depends: ${misc:Depends},
          gjs,
          libgjs0e (= ${binary:Version}),
-         libgirepository1.0-dev (>= 1.41.4)
+         libgirepository1.0-dev (>= 1.41.4),
+         libmozjs-31-dev
 Description: Mozilla-based javascript bindings for the GNOME platform
  Makes it possible for applications to use all of GNOME's platform
  libraries using the Javascript language. It's mainly based on the


### PR DESCRIPTION
According to
https://autotools.io/pkgconfig/dependencies.html#pkgconfig.static-link,
Requires.private are still brought in when you link statically. Since the
dev package must cover both static and dynamic linking, it still needs
the dependency on libmozjs-31-dev even though it won't be used when you
link dynamically.

https://phabricator.endlessm.com/T14461